### PR TITLE
Add German Story Mania Tonies (Malva and Mello)

### DIFF
--- a/German/Story Mania/Malva.nfc
+++ b/German/Story Mania/Malva.nfc
@@ -1,0 +1,33 @@
+Filetype: Flipper NFC device
+Version: 4
+# Device type can be ISO14443-3A, ISO14443-3B, ISO14443-4A, ISO14443-4B, ISO15693-3, FeliCa, NTAG/Ultralight, Mifare Classic, Mifare Plus, Mifare DESFire, SLIX, ST25TB, NTAG4xx, Type 4 Tag, EMV
+Device type: SLIX
+# UID is common for all formats
+UID: E0 04 03 50 2B 5F 83 7A
+# ISO15693-3 specific data
+# Data Storage Format Identifier
+DSFID: 00
+# Application Family Identifier
+AFI: 00
+# IC Reference - Vendor specific meaning
+IC Reference: 03
+# Lock Bits
+Lock DSFID: false
+Lock AFI: false
+# Number of memory blocks, valid range = 1..256
+Block Count: 8
+# Size of a single memory block, valid range = 01...20 (hex)
+Block Size: 04
+Data Content: BF D5 AF E2 D5 D3 4C 58 62 7D DD D9 DF DE 47 B2 D7 D9 CD 78 77 36 E2 E6 49 F0 DC 86 86 F2 F0 09
+# Block Security Status: 01 = locked, 00 = not locked
+Security Status: 00 00 00 00 00 00 00 00
+# SLIX specific data
+# SLIX capabilities field affects emulation modes. Possible options: Default, AcceptAllPasswords
+Capabilities: Default
+# Passwords are optional. If a password is omitted, a default value will be used
+Password Privacy: 7F FD 6E 5B
+Password Destroy: 0F 0F 0F 0F
+Password EAS: 00 00 00 00
+Privacy Mode: false
+# SLIX Lock Bits
+Lock EAS: false

--- a/German/Story Mania/Mello.nfc
+++ b/German/Story Mania/Mello.nfc
@@ -1,0 +1,33 @@
+Filetype: Flipper NFC device
+Version: 4
+# Device type can be ISO14443-3A, ISO14443-3B, ISO14443-4A, ISO14443-4B, ISO15693-3, FeliCa, NTAG/Ultralight, Mifare Classic, Mifare Plus, Mifare DESFire, SLIX, ST25TB, NTAG4xx, Type 4 Tag, EMV
+Device type: SLIX
+# UID is common for all formats
+UID: E0 04 03 50 2B 9F 5C 89
+# ISO15693-3 specific data
+# Data Storage Format Identifier
+DSFID: 00
+# Application Family Identifier
+AFI: 00
+# IC Reference - Vendor specific meaning
+IC Reference: 03
+# Lock Bits
+Lock DSFID: false
+Lock AFI: false
+# Number of memory blocks, valid range = 1..256
+Block Count: 8
+# Size of a single memory block, valid range = 01...20 (hex)
+Block Size: 04
+Data Content: 0A BF 9B 88 27 31 9A B0 79 2F 7B 16 CF 69 99 21 85 6B 71 C3 83 50 69 E9 9B 2E 1D 72 E2 E0 4E 98
+# Block Security Status: 01 = locked, 00 = not locked
+Security Status: 00 00 00 00 00 00 00 00
+# SLIX specific data
+# SLIX capabilities field affects emulation modes. Possible options: Default, AcceptAllPasswords
+Capabilities: Default
+# Passwords are optional. If a password is omitted, a default value will be used
+Password Privacy: 7F FD 6E 5B
+Password Destroy: 0F 0F 0F 0F
+Password EAS: 00 00 00 00
+Privacy Mode: false
+# SLIX Lock Bits
+Lock EAS: false


### PR DESCRIPTION
Adds two Swiss Pocket Tonies from the Migros Story Mania promotion:
- **Malva**: https://migipedia.migros.ch/de/tonies-story-mania-malva
- **Mello**: https://migipedia.migros.ch/de/tonies-story-mania-mello
### Validation
- [x] Placed under `German/Story Mania/`
- [x] Validated NFC tags with SLIX format & complete 32-byte data content
- [x] UNIX LF line endings